### PR TITLE
Add BLE beaconkey

### DIFF
--- a/token_extractor.py
+++ b/token_extractor.py
@@ -101,6 +101,13 @@ class XiaomiCloudConnector:
             "data": '{"getVirtualModel":false,"getHuamiDevices":0}'
         }
         return self.execute_api_call(url, params)
+        
+    def get_beaconkey(self, country, did):
+        url = self.get_api_url(country) + "/v2/device/blt_get_beaconkey"
+        params = {
+            "data": '{"did":"' + did  + '","pdid":1}'
+        }
+        return self.execute_api_call(url, params)
 
     def execute_api_call(self, url, params):
         headers = {
@@ -205,6 +212,9 @@ if logged:
                     print("   NAME:  " + device["name"])
                 if "did" in device:
                     print("   ID:    " + device["did"])
+                    if "blt" in device["did"]:
+                        beaconkey = connector.get_beaconkey(current_server, device["did"])
+                        print("   KEY:   " + beaconkey["result"]["beaconkey"])
                 if "localip" in device:
                     print("   IP:    " + device["localip"])
                 if "token" in device:


### PR DESCRIPTION
Based on the work of @rezmus in issue #15 I made a pull request for his change (all credits for @rezmus). 

I only changed the python file, I'm not able to make the exe file for windows.

I tested his change and it works fine. Result of a BLE device with an encryption key is (Yes, I changed the ID, keys and token to fake ones). :

```
   ---------
   NAME:  temperature
   ID:    blt.3.15chu6xx85c00
   KEY:   f2ac4a21d0c7a315cb9b50bdbac4d200
   IP:    31.141.195.190
   TOKEN: 68b132e10634cac004fe472d
   MODEL: miaomiaoce.sensor_ht.t2
   ---------
```

If the device doesn't have/require a key, it will show `FFFFFFFF` at the end of the KEY. 

```
   ---------
   NAME:  Mi Temperature and Humidity Monitor
   ID:    blt.3.u3g008x44600
   KEY:   08073eec970bf276191e7a08FFFFFFFF
   IP:    
   TOKEN: bcec6b6f6a14d7d1fb176f52
   MODEL: cleargrass.sensor_ht.dk1
   ---------
```