### PR TITLE
Use python-alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Use the smaller docker image. It will make run_docker command much faster for a first run