### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python3 token_extractor.py
 If you have problems with using this tool try following solutions:
 - Make yourself sure that you provide correct credentials (_e.g. not ones from Roborock app!_)
 - Remove Cloudflare DNS
-- Disable network ad blockers (AdGuard, PiHole, etc.)
+- Disable network ad blockers (AdGuard, PiHole, etc.) and restrictions (UniFi Country Restriction etc.)
 - Open 2FA link on the same device that runs Tokens Extractor
 
 ## Home Assistant additional tools


### PR DESCRIPTION
My edit is to add hint for UniFi users in terms of troubles and timeouts.

Story:

Even if the mi device is stored on a European server, it looks like some connections are proxied through China servers.
In my case, I had to disable Country Restriction in my UniFi - actually, I just allowed outgoing for the time when I was fetching tokens.

![UniFi Country Restriction](https://user-images.githubusercontent.com/2881159/162625003-c6e32028-198b-428d-b870-4c6ce71cb674.png)
