### PR TITLE
Indicate that the Windows app works fine in wine

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You will need to provide Xiaomi Home credentials (_not ones from Roborock app_):
 
 In return all of your devices connected to account will be listed, together with their name and IP address.
 
-## Windows
+## Windows or Wine
 Download and run [token_extractor.exe](https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor/releases/latest/download/token_extractor.exe).
 
 ## Linux & Home Assistant (in [SSH & Web Terminal](https://github.com/hassio-addons/addon-ssh))


### PR DESCRIPTION
I've tested the different solutions and found that the Windows application is simple and clean and therefore runs perfectly fine in 🍷**Wine**. 

I specifically have tested the **Wine 7.0 Flatpak from Flathub** which was most prominently placed in the KDE Discover Store on OpenSuse Tumbleweed.