### PR TITLE
Add check if pycryptodome or pycryptodomex is installed

### DIFF
--- a/token_extractor.py
+++ b/token_extractor.py
@@ -9,7 +9,11 @@ from getpass import getpass
 from sys import platform
 
 import requests
-from Crypto.Cipher import ARC4
+
+try:
+    from Crypto.Cipher import ARC4
+except ImportError:
+    from Cryptodome.Cipher import ARC4
 
 if platform != "win32":
     import readline


### PR DESCRIPTION
When running script on Ubuntu, you cannot use pip out of the box but sudo install python3-pycryptodome. When toy do it it actually installs pycryptodomex, which needs to use Cryptodome.Cipher to import