### PR TITLE
Update token_extractor.py

### DIFF
--- a/token_extractor.py
+++ b/token_extractor.py
@@ -32,7 +32,7 @@ parser.add_argument("-ni", "--non_interactive", required=False, help="Non-nterac
 parser.add_argument("-u", "--username", required=False, help="Username")
 parser.add_argument("-p", "--password", required=False, help="Password")
 parser.add_argument("-s", "--server", required=False, help="Server", choices=[*SERVERS, ""])
-parser.add_argument("-l", "--log_level", required=False, help="Log level", default="CRITICAL", choices=list(logging.getLevelNamesMapping().keys()))
+parser.add_argument("-l", "--log_level", required=False, help="Log level", default="CRITICAL", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
 parser.add_argument("-o", "--output", required=False, help="Output file")
 parser.add_argument("--host", required=False, help="Host")
 args = parser.parse_args()
@@ -40,7 +40,7 @@ if args.non_interactive and (not args.username or not args.password):
     parser.error("You need to specify username and password or run as interactive.")
 
 _LOGGER = logging.getLogger("token_extractor")
-_LOGGER.level = logging.getLevelNamesMapping()[args.log_level.upper()]
+_LOGGER.level = getattr(logging, args.log_level.upper())
 handler = logging.StreamHandler(sys.stdout)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 handler.setFormatter(formatter)


### PR DESCRIPTION
**Fix log level argument handling in command line parser**

Tested on laptop with python version: `3.10.12`
Before fix got this output: (after installing requirements)
Traceback (most recent call last):
  File "/home/patryk/Xiaomi-cloud-tokens-extractor/./token_extractor.py", line 35, in <module>
    parser.add_argument("-l", "--log_level", required=False, help="Log level", default="CRITICAL", choices=list(logging.getLevelNamesMapping().keys()))
AttributeError: module 'logging' has no attribute 'getLevelNamesMapping'

And my colleague didn't have this runtime error, but kept getting invalid username or password.

For previous people who got errors with invalid username or password earlier, this should resolve this problem.