### PR TITLE
Prevent download error if token_extractor.zip exists

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,11 @@ set -o errexit  # fail on first error
 set -o nounset  # fail on undef var
 set -o pipefail # fail on first error in pipe
 
+if [ -f "token_extractor.zip" ]; then
+    echo "File exists, exiting..."
+    exit 1   # or exit 0 if you want a 'successful' exit
+fi
+
 curl --silent --fail --show-error --location --remote-name --remote-header-name\
   https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor/releases/latest/download/token_extractor.zip
 unzip token_extractor.zip


### PR DESCRIPTION
Add check for existing token_extractor.zip file, as this errors (at least on Mac):
```
$ bash <(curl -L https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor/raw/master/run.sh)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   762  100   762    0     0   1993      0 --:--:-- --:--:-- --:--:--  1993
curl: (56) Failure writing output to destination, passed 63 returned 4294967295
```