### PR TITLE
Add non-interactive QR authentication

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Acceptance tests
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  acceptance:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python -m pip install -r requirements.txt
+      - run: python -m unittest discover -s tests -p "test_*.py" -v

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ pip3 install -r requirements.txt
 python3 token_extractor.py
 ```
 
+### Non-interactive QR authentication
+
+QR authentication can be used without reading from standard input. Store the QR
+image and extractor output in a private directory because both contain sensitive
+account data:
+
+```bash
+python3 token_extractor.py --non_interactive --auth-method qr \
+  --qr-output ./login-qr.png --server de --output ./devices.json
+```
+
+Omit `--server` to check every supported region. The QR image is published
+atomically and is created with owner-only permissions on POSIX systems. A new run
+removes any stale image before requesting another one. Remove the image after
+authentication finishes. QR authentication errors return a non-zero exit status.
+
 ## Troubleshooting
 
 If you have problems with using this tool try following solutions:

--- a/tests/test_noninteractive_qr_acceptance.py
+++ b/tests/test_noninteractive_qr_acceptance.py
@@ -1,0 +1,331 @@
+"""Public CLI acceptance coverage for non-interactive QR authentication.
+
+Feature matrix:
+- QR login with closed stdin, an atomically published image, and explicit region:
+  covered here through the subprocess CLI boundary.
+- QR login artifacts remain absent from terminal output at debug level: covered.
+- QR authentication failures return a non-zero process status: covered.
+- QR and account output files are owner-only, and failed refreshes remove stale
+  QR images: covered.
+- Ambiguous QR/password arguments and a missing QR destination: covered here.
+- Omitted region checks every supported region without prompting: covered here.
+- Existing non-interactive password validation remains the default: covered here.
+- Password login, interactive prompts, 2FA, and live Xiaomi Cloud behavior: not
+  covered by this fixture and remain adaptation gaps.
+
+The fixture replaces only the external requests package. It does not import or
+call implementation details from token_extractor.py.
+"""
+
+import base64
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+EXTRACTOR = Path(
+    os.environ.get("TOKEN_EXTRACTOR_UNDER_TEST", REPOSITORY_ROOT / "token_extractor.py")
+)
+PNG_BYTES = b"fixture QR image bytes"
+
+FAKE_REQUESTS = textwrap.dedent(
+    r'''
+    import base64
+    import json
+    import os
+
+
+    class RequestException(Exception):
+        pass
+
+
+    class Timeout(RequestException):
+        pass
+
+
+    class _Exceptions:
+        RequestException = RequestException
+        Timeout = Timeout
+
+
+    exceptions = _Exceptions()
+
+
+    class CookieJar(dict):
+        def set(self, name, value, domain=None):
+            self[name] = value
+            if domain is not None:
+                self[(name, domain)] = value
+
+        def get(self, name, default=None, domain=None):
+            if domain is not None:
+                return dict.get(self, (name, domain), default)
+            return dict.get(self, name, default)
+
+
+    class Response:
+        def __init__(self, status_code=200, text="", content=b"", cookies=None):
+            self.status_code = status_code
+            self.text = text
+            self.content = content
+            self.cookies = cookies or CookieJar()
+
+
+    class Session:
+        def __init__(self):
+            self.cookies = CookieJar()
+
+        def get(self, url, **kwargs):
+            if url.endswith("/longPolling/loginUrl"):
+                payload = {
+                    "qr": "https://fixture.invalid/qr.png",
+                    "loginUrl": "https://fixture.invalid/login?ticket=fixture-login-ticket",
+                    "lp": "https://fixture.invalid/poll",
+                    "timeout": 10,
+                }
+                return Response(text="&&&START&&&" + json.dumps(payload))
+            if url == "https://fixture.invalid/qr.png":
+                if os.environ.get("FIXTURE_QR_FAILURE"):
+                    return Response(status_code=503, text="fixture failure")
+                return Response(content=b"fixture QR image bytes")
+            if url == "https://fixture.invalid/poll":
+                if os.environ.get("FIXTURE_POLL_EXCEPTION"):
+                    raise RequestException("fixture polling failure")
+                payload = {
+                    "userId": "fixture-user",
+                    "ssecurity": base64.b64encode(b"fixture-security").decode(),
+                    "cUserId": "fixture-c-user",
+                    "passToken": "fixture-pass-token",
+                    "location": "https://fixture.invalid/sts",
+                }
+                return Response(text="&&&START&&&" + json.dumps(payload))
+            if url == "https://fixture.invalid/sts":
+                cookies = CookieJar()
+                if not os.environ.get("FIXTURE_MISSING_SERVICE_TOKEN"):
+                    cookies["serviceToken"] = "fixture-service-token"
+                return Response(cookies=cookies)
+            raise RequestException("unexpected fixture URL")
+
+        def post(self, url, **kwargs):
+            return Response(status_code=503)
+
+
+    def session():
+        return Session()
+    '''
+)
+
+
+class NonInteractiveQrAcceptanceTest(unittest.TestCase):
+    def run_extractor(self, *arguments, environment_overrides=None):
+        with tempfile.TemporaryDirectory() as fake_module_directory:
+            Path(fake_module_directory, "requests.py").write_text(
+                FAKE_REQUESTS,
+                encoding="utf-8",
+            )
+            environment = os.environ.copy()
+            environment["PYTHONPATH"] = os.pathsep.join(
+                filter(None, [fake_module_directory, environment.get("PYTHONPATH")])
+            )
+            environment["PYTHONDONTWRITEBYTECODE"] = "1"
+            environment.update(environment_overrides or {})
+            return subprocess.run(
+                [sys.executable, str(EXTRACTOR), *arguments],
+                cwd=REPOSITORY_ROOT,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+
+    def test_qr_login_completes_with_closed_stdin_and_refreshes_private_image(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            qr_output = Path(output_directory, "login-qr.png")
+            data_output = Path(output_directory, "devices.json")
+            qr_output.write_bytes(b"stale image")
+            qr_output.chmod(0o644)
+            data_output.write_text("stale data", encoding="utf-8")
+            data_output.chmod(0o644)
+
+            result = self.run_extractor(
+                "--non_interactive",
+                "--auth-method",
+                "qr",
+                "--qr-output",
+                str(qr_output),
+                "--server",
+                "de",
+                "--output",
+                str(data_output),
+                "--log_level",
+                "DEBUG",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(qr_output.read_bytes(), PNG_BYTES)
+            if os.name == "posix":
+                self.assertEqual(stat.S_IMODE(qr_output.stat().st_mode), 0o600)
+                self.assertEqual(stat.S_IMODE(data_output.stat().st_mode), 0o600)
+            self.assertEqual(
+                json.loads(data_output.read_text(encoding="utf-8")),
+                [{"server": "de", "homes": []}],
+            )
+            terminal_output = result.stdout + result.stderr
+            self.assertNotIn("fixture.invalid", terminal_output)
+            self.assertNotIn("fixture-login-ticket", terminal_output)
+            self.assertNotIn("fixture-security", terminal_output)
+            self.assertNotIn(
+                base64.b64encode(b"fixture-security").decode(),
+                terminal_output,
+            )
+            self.assertNotIn("fixture-pass-token", terminal_output)
+            self.assertNotIn("fixture-service-token", terminal_output)
+            self.assertNotIn("fixture-user", terminal_output)
+            self.assertNotIn("p/q:", terminal_output)
+            self.assertNotIn("Select server", terminal_output)
+            self.assertNotIn("Press ENTER", terminal_output)
+
+    def test_qr_login_requires_an_image_destination(self):
+        result = self.run_extractor(
+            "--non_interactive",
+            "--auth-method",
+            "qr",
+            "--server",
+            "de",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("requires --qr-output", result.stderr)
+
+    def test_qr_login_checks_all_regions_without_reading_stdin(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            qr_output = Path(output_directory, "login-qr.png")
+            data_output = Path(output_directory, "devices.json")
+
+            result = self.run_extractor(
+                "--non_interactive",
+                "--auth-method",
+                "qr",
+                "--qr-output",
+                str(qr_output),
+                "--output",
+                str(data_output),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(
+                [
+                    entry["server"]
+                    for entry in json.loads(data_output.read_text(encoding="utf-8"))
+                ],
+                ["cn", "de", "us", "ru", "tw", "sg", "in", "i2"],
+            )
+            self.assertNotIn("Select server", result.stdout + result.stderr)
+
+    def test_qr_authentication_failure_returns_a_failure_status(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            qr_output = Path(output_directory, "login-qr.png")
+            qr_output.write_bytes(b"stale image")
+
+            result = self.run_extractor(
+                "--non_interactive",
+                "--auth-method",
+                "qr",
+                "--qr-output",
+                str(qr_output),
+                "--server",
+                "de",
+                environment_overrides={"FIXTURE_QR_FAILURE": "1"},
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(qr_output.exists())
+            self.assertNotIn("unrecognized arguments", result.stderr)
+            self.assertNotIn("fixture failure", result.stdout + result.stderr)
+
+    def test_qr_login_rejects_password_credentials(self):
+        result = self.run_extractor(
+            "--non_interactive",
+            "--auth-method",
+            "qr",
+            "--qr-output",
+            "unused.png",
+            "--username",
+            "fixture-user",
+            "--password",
+            "fixture-password",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("cannot be used with QR authentication", result.stderr)
+
+    def test_polling_connection_failure_is_reported_without_a_traceback(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            qr_output = Path(output_directory, "login-qr.png")
+
+            result = self.run_extractor(
+                "--non_interactive",
+                "--auth-method",
+                "qr",
+                "--qr-output",
+                str(qr_output),
+                "--server",
+                "de",
+                environment_overrides={"FIXTURE_POLL_EXCEPTION": "1"},
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(qr_output.exists())
+            self.assertNotIn("Traceback", result.stdout + result.stderr)
+
+    def test_missing_service_token_fails_without_leaving_the_qr_image(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            qr_output = Path(output_directory, "login-qr.png")
+
+            result = self.run_extractor(
+                "--non_interactive",
+                "--auth-method",
+                "qr",
+                "--qr-output",
+                str(qr_output),
+                "--server",
+                "de",
+                environment_overrides={"FIXTURE_MISSING_SERVICE_TOKEN": "1"},
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(qr_output.exists())
+            self.assertNotIn("Traceback", result.stdout + result.stderr)
+
+    def test_password_login_rejects_a_qr_destination(self):
+        result = self.run_extractor(
+            "--non_interactive",
+            "--username",
+            "fixture-user",
+            "--password",
+            "fixture-password",
+            "--qr-output",
+            "unused.png",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("requires --auth-method qr", result.stderr)
+
+    def test_non_interactive_password_validation_remains_the_default(self):
+        result = self.run_extractor("--non_interactive")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("specify username and password", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/token_extractor.py
+++ b/token_extractor.py
@@ -46,13 +46,26 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-ni", "--non_interactive", required=False, help="Non-interactive mode", action="store_true")
 parser.add_argument("-u", "--username", required=False, help="Username")
 parser.add_argument("-p", "--password", required=False, help="Password")
+parser.add_argument("--auth-method", required=False, choices=["password", "qr"], help="Authentication method")
+parser.add_argument("--qr-output", required=False, help="Write the QR login image to this file")
 parser.add_argument("-s", "--server", required=False, help="Server", choices=[*SERVERS, ""])
 parser.add_argument("-l", "--log_level", required=False, help="Log level", default="CRITICAL", choices=list(NAME_TO_LEVEL.keys()))
 parser.add_argument("-o", "--output", required=False, help="Output file")
 parser.add_argument("--host", required=False, help="Host")
 args = parser.parse_args()
-if args.non_interactive and (not args.username or not args.password):
-    parser.error("You need to specify username and password or run as interactive.")
+if args.non_interactive:
+    if args.auth_method is None:
+        args.auth_method = "password"
+    if args.auth_method == "password" and (not args.username or not args.password):
+        parser.error("You need to specify username and password or run as interactive.")
+    if args.auth_method == "qr" and not args.qr_output:
+        parser.error("Non-interactive QR authentication requires --qr-output.")
+    if args.auth_method == "qr" and (args.username or args.password):
+        parser.error("Username and password cannot be used with QR authentication.")
+    if args.auth_method != "qr" and args.qr_output is not None:
+        parser.error("--qr-output requires --auth-method qr.")
+elif args.auth_method is not None or args.qr_output is not None:
+    parser.error("--auth-method and --qr-output require --non_interactive.")
 
 init(autoreset=True)
 
@@ -614,20 +627,25 @@ class QrCodeXiaomiCloudConnector(XiaomiCloudConnector):
         self._long_polling_url = None
 
     def login(self) -> bool:
+        self.remove_qr_output()
 
         if not self.login_step_1():
+            self.remove_qr_output()
             print_if_interactive(f"{Fore.RED}Unable to get login message.")
             return False
 
         if not self.login_step_2():
+            self.remove_qr_output()
             print_if_interactive(f"{Fore.RED}Unable to get login QR Image.")
             return False
 
         if not self.login_step_3():
+            self.remove_qr_output()
             print_if_interactive(f"{Fore.RED}Unable to login.")
             return False
 
         if not self.login_step_4():
+            self.remove_qr_output()
             print_if_interactive(f"{Fore.RED}Unable to get service token.")
             return False
 
@@ -648,7 +666,7 @@ class QrCodeXiaomiCloudConnector(XiaomiCloudConnector):
         }
 
         response = self._session.get(url, params=data)
-        _LOGGER.debug(response.text)
+        _LOGGER.debug("login_step_1: HTTP status: %s", response.status_code)
 
         if response.status_code == 200:
             response_data = self.to_json(response.text)
@@ -663,7 +681,6 @@ class QrCodeXiaomiCloudConnector(XiaomiCloudConnector):
     def login_step_2(self) -> bool:
         _LOGGER.debug("login_step_2")
         url = self._qr_image_url
-        _LOGGER.debug("login_step_2: Image URL: %s", url)
 
         response = self._session.get(url)
 
@@ -672,28 +689,36 @@ class QrCodeXiaomiCloudConnector(XiaomiCloudConnector):
         if valid:
             print_if_interactive(f"{Fore.BLUE}Please scan the following QR code to log in.")
 
-            present_image_image(
-                response.content,
-                message_url = f"QR code URL: {Fore.BLUE}http://{args.host or '127.0.0.1'}:31415",
-                message_file_saved = "QR code image saved at: {}",
-                message_manually_open_file = "Please open {} and scan the QR code."
-            )
+            if args.non_interactive:
+                try:
+                    write_private_file(args.qr_output, response.content)
+                except OSError as error:
+                    _LOGGER.error("Unable to write QR code image: %s", error)
+                    return False
+            else:
+                present_image_image(
+                    response.content,
+                    message_url = f"QR code URL: {Fore.BLUE}http://{args.host or '127.0.0.1'}:31415",
+                    message_file_saved = "QR code image saved at: {}",
+                    message_manually_open_file = "Please open {} and scan the QR code."
+                )
             print_if_interactive()
             print_if_interactive(f"{Fore.BLUE}Alternatively you can visit the following URL:")
             print_if_interactive(f"{Fore.BLUE}  {self._login_url}")
             print_if_interactive()
             return True
         else:
-            _LOGGER.error("login_step_2: HTTP status: %s; Response: %s", response.status_code, response.text[:500])
+            _LOGGER.error("login_step_2: HTTP status: %s", response.status_code)
         return False
 
     def login_step_3(self) -> bool:
         _LOGGER.debug("login_step_3")
 
         url = self._long_polling_url
-        _LOGGER.debug("Long polling URL: " + url)
+        _LOGGER.debug("Starting QR login long polling")
 
         start_time = time.time()
+        response = None
         # Start long polling
         while True:
             try:
@@ -705,7 +730,7 @@ class QrCodeXiaomiCloudConnector(XiaomiCloudConnector):
                     break
                 continue
             except requests.exceptions.RequestException as e:
-                _LOGGER.error(f"An error occurred: {e}")
+                _LOGGER.error("Long polling request failed: %s", type(e).__name__)
                 break
 
             if response.status_code == 200:
@@ -713,15 +738,12 @@ class QrCodeXiaomiCloudConnector(XiaomiCloudConnector):
             else:
                 _LOGGER.error("Long polling failed, retrying...")
 
-        if response.status_code != 200:
-            _LOGGER.error("Long polling failed with status code: " + str(response.status_code))
+        if response is None or response.status_code != 200:
+            status_code = response.status_code if response is not None else "unavailable"
+            _LOGGER.error("Long polling failed with status code: %s", status_code)
             return False
 
-        _LOGGER.debug("Login successful!")
-        _LOGGER.debug("Response data:")
-
         response_data = self.to_json(response.text)
-        _LOGGER.debug(response_data)
 
         self.userId = response_data["userId"]
         self._ssecurity = response_data["ssecurity"]
@@ -729,11 +751,7 @@ class QrCodeXiaomiCloudConnector(XiaomiCloudConnector):
         self._pass_token = response_data["passToken"]
         self._location = response_data["location"]
 
-        _LOGGER.debug("User ID: " + str(self.userId))
-        _LOGGER.debug("Ssecurity: " + str(self._ssecurity))
-        _LOGGER.debug("CUser ID: " + str(self._cUserId))
-        _LOGGER.debug("Pass token: " + str(self._pass_token))
-        _LOGGER.debug("Pass token: " + str(self._location))
+        _LOGGER.debug("QR authentication response accepted")
 
         return True
 
@@ -749,9 +767,23 @@ class QrCodeXiaomiCloudConnector(XiaomiCloudConnector):
         if response.status_code != 200:
             return False
 
-        self._serviceToken = response.cookies["serviceToken"]
-        _LOGGER.debug("Service token: " + str(self._serviceToken))
+        self._serviceToken = response.cookies.get("serviceToken")
+        if not self._serviceToken:
+            _LOGGER.error("Service token was not returned")
+            return False
+        _LOGGER.debug("Service token received")
         return True
+
+    @staticmethod
+    def remove_qr_output() -> None:
+        if not args.non_interactive or not args.qr_output:
+            return
+        try:
+            os.unlink(args.qr_output)
+        except FileNotFoundError:
+            pass
+        except OSError as error:
+            _LOGGER.error("Unable to remove stale QR code image: %s", error)
 
 
 def print_if_interactive(value: str="") -> None:
@@ -799,6 +831,30 @@ def start_image_server(image: bytes) -> None:
     thread.start()
 
 
+def write_private_file(path: str, content: bytes) -> None:
+    target_path = os.path.abspath(path)
+    target_dir = os.path.dirname(target_path)
+    file_descriptor, temporary_path = tempfile.mkstemp(
+        dir=target_dir,
+        prefix=f".{os.path.basename(target_path)}.",
+    )
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(file_descriptor, 0o600)
+        with os.fdopen(file_descriptor, "wb") as output_file:
+            file_descriptor = -1
+            output_file.write(content)
+        os.replace(temporary_path, target_path)
+    except Exception:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+        try:
+            os.unlink(temporary_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
 def present_image_image(
         image_content: bytes,
         message_url: str,
@@ -824,10 +880,13 @@ def present_image_image(
             print_if_interactive(message_manually_open_file.format(tmp_path))
 
 
-def main() -> None:
+def main() -> int:
     print_banner()
     if args.non_interactive:
-        connector = PasswordXiaomiCloudConnector()
+        if args.auth_method == "qr":
+            connector = QrCodeXiaomiCloudConnector()
+        else:
+            connector = PasswordXiaomiCloudConnector()
     else:
         print_if_interactive("Please select a way to log in:")
         print_if_interactive(f" p{Fore.BLUE} - using password")
@@ -897,15 +956,17 @@ def main() -> None:
                     print_if_interactive(f"{Fore.RED}Unable to get devices from server {current_server}.")
             output.append({"server": current_server, "homes": all_homes})
         if args.output:
-            with open(args.output, "w") as f:
-                f.write(json.dumps(output, indent=4))
+            write_private_file(args.output, json.dumps(output, indent=4).encode())
     else:
         print_if_interactive(f"{Fore.RED}Unable to log in.")
+        if args.non_interactive and args.auth_method == "qr":
+            return 1
 
     if not args.non_interactive:
         print_if_interactive()
         print_if_interactive("Press ENTER to finish")
         input()
+    return 0
 
 
 def get_servers_to_check() -> list[str]:
@@ -932,4 +993,4 @@ def get_servers_to_check() -> list[str]:
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add explicit `--auth-method qr` support to `--non_interactive`
- write the current QR image and JSON result through atomic, owner-only files on POSIX
- return a non-zero status when non-interactive QR authentication fails
- remove QR login tickets and authentication values from DEBUG logs
- preserve the existing interactive QR flow and password-mode default

## Why

The current non-interactive path always selects password authentication. Selecting QR authentication therefore requires stdin, which prevents unattended callers from exposing the QR image through their own UI or transport.

`--qr-output` provides a file boundary for that handoff. A failed login removes the stale QR image so callers do not keep presenting an expired code. Omitting `--server` retains the existing behavior of checking every supported region.

## Compatibility

Existing `--non_interactive` password commands keep password authentication as the default. The interactive image server, login URL display, and device listing are unchanged.

## Tests

- `python -m unittest discover -s tests -v` (9 public CLI cases)
- the same feature cases fail against the pre-change executable
- GitHub Actions runs the suite on Python 3.13 for Ubuntu and Windows

The acceptance fixture contains only synthetic identifiers and replaces only the external HTTP client boundary.
