### PR TITLE
Add targeted BLE key output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Acceptance tests
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  acceptance:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python -m pip install -r requirements.txt
+      - run: python -m unittest discover -s tests -p "test_*.py" -v

--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ If you have problems with using this tool try following solutions:
 - Use QR code authentication instead of username & password
 - Just wait - there is a [limit of 3/5 (depending on region) 2FA requests per day](https://account.xiaomi.com/helpcenter/faq/en_US/02.faqs/05.sms-and-email-verification-code/faq-3)
 
+### Retrieve one BLE key non-interactively
+
+Use `--target-mac` with `--key-output` when an automation only needs the BLE
+encryption key for one device. The target must be a 48-bit MAC address; the
+example below uses a locally administered example address:
+
+```bash
+python3 token_extractor.py --non_interactive \
+  --username "$XIAOMI_USERNAME" --password "$XIAOMI_PASSWORD" --server de \
+  --target-mac 02:00:00:00:00:01 --key-output ./ble-key.txt
+```
+
+The command exits with a failure if the target or its key is unavailable. To
+avoid overwriting a previously retrieved key, `--key-output` must name a new
+file. On POSIX systems that file is created with owner-only permissions. The key
+is not printed in non-interactive mode.
+
 ## Home Assistant additional tools
 
 * [Map extractor](https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor) - live map for Xiaomi Vacuums

--- a/tests/test_targeted_ble_key_acceptance.py
+++ b/tests/test_targeted_ble_key_acceptance.py
@@ -1,0 +1,331 @@
+"""Public CLI acceptance coverage for targeted BLE key output.
+
+Feature matrix:
+- Retrieve only one device's BLE key through the non-interactive subprocess CLI:
+  covered here with a synthetic cloud boundary.
+- Owner-only, no-overwrite key output and failure when the target is absent:
+  covered here.
+- Non-target BLE devices are not queried, and failed targeting preserves existing
+  account output: covered here.
+- Existing account-wide JSON output without the new flags: covered here.
+- QR login, interactive prompts, 2FA, and live Xiaomi Cloud behavior: not covered
+  by this fixture and remain adaptation gaps.
+
+The fixture replaces only the external requests package. It does not import or
+call implementation details from token_extractor.py. All identities, addresses,
+and keys below are explicitly synthetic test data.
+"""
+
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+EXTRACTOR = Path(
+    os.environ.get("TOKEN_EXTRACTOR_UNDER_TEST", REPOSITORY_ROOT / "token_extractor.py")
+)
+EXAMPLE_MAC = "02:00:00:00:00:01"
+EXAMPLE_KEY = "00112233445566778899AABBCCDDEEFF"
+
+FAKE_REQUESTS = textwrap.dedent(
+    r'''
+    import base64
+    import hashlib
+    import json
+    import os
+
+    try:
+        from Crypto.Cipher import ARC4
+    except ModuleNotFoundError:
+        from Cryptodome.Cipher import ARC4
+
+
+    SSECURITY = base64.b64encode(b"fixture-security").decode()
+
+
+    class RequestException(Exception):
+        pass
+
+
+    class Timeout(RequestException):
+        pass
+
+
+    class _Exceptions:
+        RequestException = RequestException
+        Timeout = Timeout
+
+
+    exceptions = _Exceptions()
+
+
+    class CookieJar(dict):
+        def set(self, name, value, domain=None):
+            self[name] = value
+            if domain is not None:
+                self[(name, domain)] = value
+
+        def get(self, name, default=None, domain=None):
+            if domain is not None:
+                return dict.get(self, (name, domain), default)
+            return dict.get(self, name, default)
+
+
+    class Response:
+        def __init__(self, status_code=200, text="", content=b"", cookies=None):
+            self.status_code = status_code
+            self.text = text
+            self.content = content
+            self.cookies = cookies or CookieJar()
+
+
+    def encrypted_response(fields, payload):
+        signed_nonce = hashlib.sha256(
+            base64.b64decode(SSECURITY) + base64.b64decode(fields["_nonce"])
+        ).digest()
+        cipher = ARC4.new(signed_nonce)
+        cipher.encrypt(bytes(1024))
+        encrypted = cipher.encrypt(json.dumps(payload).encode())
+        return Response(text=base64.b64encode(encrypted).decode())
+
+
+    class Session:
+        def __init__(self):
+            self.cookies = CookieJar()
+
+        def get(self, url, **kwargs):
+            if "/pass/serviceLogin" in url:
+                return Response(text='&&&START&&&{"_sign":"fixture-sign"}')
+            if url == "https://fixture.invalid/sts":
+                cookies = CookieJar()
+                cookies["serviceToken"] = "fixture-service-token"
+                return Response(cookies=cookies)
+            raise RequestException("unexpected fixture URL")
+
+        def post(self, url, **kwargs):
+            if url.endswith("/pass/serviceLoginAuth2"):
+                payload = {
+                    "ssecurity": SSECURITY,
+                    "userId": "fixture-user",
+                    "cUserId": "fixture-c-user",
+                    "passToken": "fixture-pass-token",
+                    "location": "https://fixture.invalid/sts",
+                    "code": 0,
+                }
+                return Response(text="&&&START&&&" + json.dumps(payload))
+
+            fields = kwargs["params"]
+            if url.endswith("/v2/homeroom/gethome"):
+                return encrypted_response(fields, {"result": {"homelist": [{"id": 7}]}})
+            if url.endswith("/v2/user/get_device_cnt"):
+                return encrypted_response(
+                    fields,
+                    {"result": {"share": {"share_family": []}}},
+                )
+            if url.endswith("/v2/home/home_device_list"):
+                return encrypted_response(
+                    fields,
+                    {
+                        "result": {
+                            "device_info": [
+                                {
+                                    "did": "blt.fixture-device",
+                                    "name": "Fixture sensor",
+                                    "mac": "02:00:00:00:00:01",
+                                    "model": "fixture.sensor",
+                                },
+                                {
+                                    "did": "blt.fixture-other-device",
+                                    "name": "Other fixture sensor",
+                                    "mac": "02:00:00:00:00:02",
+                                    "model": "fixture.other-sensor",
+                                }
+                            ]
+                        }
+                    },
+                )
+            if url.endswith("/v2/device/blt_get_beaconkey"):
+                trace_path = os.environ.get("FIXTURE_BEACON_TRACE")
+                if trace_path:
+                    with open(trace_path, "a", encoding="utf-8") as trace_file:
+                        trace_file.write("call\n")
+                beacon_key = (
+                    ""
+                    if os.environ.get("FIXTURE_EMPTY_KEY")
+                    else "00112233445566778899AABBCCDDEEFF"
+                )
+                return encrypted_response(
+                    fields,
+                    {"result": {"beaconkey": beacon_key}},
+                )
+            raise RequestException("unexpected fixture URL")
+
+
+    def session():
+        return Session()
+    '''
+)
+
+
+class TargetedBleKeyAcceptanceTest(unittest.TestCase):
+    def run_extractor(self, *arguments, environment_overrides=None, server="de"):
+        with tempfile.TemporaryDirectory() as fake_module_directory:
+            Path(fake_module_directory, "requests.py").write_text(
+                FAKE_REQUESTS,
+                encoding="utf-8",
+            )
+            environment = os.environ.copy()
+            environment["PYTHONPATH"] = os.pathsep.join(
+                filter(None, [fake_module_directory, environment.get("PYTHONPATH")])
+            )
+            environment["PYTHONDONTWRITEBYTECODE"] = "1"
+            environment.update(environment_overrides or {})
+            command = [
+                sys.executable,
+                str(EXTRACTOR),
+                "--non_interactive",
+                "--username",
+                "fixture-user",
+                "--password",
+                "fixture-password",
+            ]
+            if server is not None:
+                command.extend(["--server", server])
+            command.extend(arguments)
+            return subprocess.run(
+                command,
+                cwd=REPOSITORY_ROOT,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+
+    def test_writes_only_the_target_key_to_a_private_file(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            key_output = Path(output_directory, "ble-key.txt")
+            beacon_trace = Path(output_directory, "beacon-calls.txt")
+
+            result = self.run_extractor(
+                "--target-mac",
+                EXAMPLE_MAC,
+                "--key-output",
+                str(key_output),
+                environment_overrides={"FIXTURE_BEACON_TRACE": str(beacon_trace)},
+                server=None,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(key_output.read_text(encoding="utf-8"), EXAMPLE_KEY + "\n")
+            if os.name == "posix":
+                self.assertEqual(stat.S_IMODE(key_output.stat().st_mode), 0o600)
+            terminal_output = result.stdout + result.stderr
+            self.assertNotIn(EXAMPLE_KEY, terminal_output)
+            self.assertNotIn("Fixture sensor", terminal_output)
+            self.assertEqual(beacon_trace.read_text(encoding="utf-8"), "call\n")
+
+    def test_refuses_to_overwrite_an_existing_key(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            key_output = Path(output_directory, "ble-key.txt")
+            key_output.write_text("previous key\n", encoding="utf-8")
+
+            result = self.run_extractor(
+                "--target-mac",
+                EXAMPLE_MAC,
+                "--key-output",
+                str(key_output),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(key_output.read_text(encoding="utf-8"), "previous key\n")
+            self.assertNotIn("unrecognized arguments", result.stderr)
+
+    def test_fails_when_the_target_device_is_absent(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            key_output = Path(output_directory, "ble-key.txt")
+
+            result = self.run_extractor(
+                "--target-mac",
+                "02:00:00:00:00:03",
+                "--key-output",
+                str(key_output),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(key_output.exists())
+            self.assertNotIn("unrecognized arguments", result.stderr)
+
+    def test_failed_target_does_not_overwrite_account_output(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            key_output = Path(output_directory, "ble-key.txt")
+            data_output = Path(output_directory, "devices.json")
+            data_output.write_text("previous output\n", encoding="utf-8")
+
+            result = self.run_extractor(
+                "--target-mac",
+                "02:00:00:00:00:03",
+                "--key-output",
+                str(key_output),
+                "--output",
+                str(data_output),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(key_output.exists())
+            self.assertEqual(
+                data_output.read_text(encoding="utf-8"),
+                "previous output\n",
+            )
+
+    def test_fails_when_the_target_has_no_key(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            key_output = Path(output_directory, "ble-key.txt")
+
+            result = self.run_extractor(
+                "--target-mac",
+                EXAMPLE_MAC,
+                "--key-output",
+                str(key_output),
+                environment_overrides={"FIXTURE_EMPTY_KEY": "1"},
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(key_output.exists())
+            self.assertNotIn("unrecognized arguments", result.stderr)
+
+    def test_rejects_a_malformed_target_before_login(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            result = self.run_extractor(
+                "--target-mac",
+                "not-a-mac",
+                "--key-output",
+                str(Path(output_directory, "ble-key.txt")),
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("must be a valid 48-bit MAC address", result.stderr)
+
+    def test_existing_account_output_remains_available_without_target_flags(self):
+        with tempfile.TemporaryDirectory() as output_directory:
+            data_output = Path(output_directory, "devices.json")
+
+            result = self.run_extractor("--output", str(data_output))
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            output = json.loads(data_output.read_text(encoding="utf-8"))
+            device = output[0]["homes"][0]["devices"][0]
+            self.assertEqual(device["mac"], EXAMPLE_MAC)
+            self.assertEqual(device["BLE_DATA"]["beaconkey"], EXAMPLE_KEY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/token_extractor.py
+++ b/token_extractor.py
@@ -42,6 +42,16 @@ NAME_TO_LEVEL = {
     "NOTSET": logging.NOTSET,
 }
 
+
+def parse_mac_address(value: str) -> str:
+    compact = re.fullmatch(r"[0-9A-Fa-f]{12}", value)
+    colon_separated = re.fullmatch(r"(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}", value)
+    hyphen_separated = re.fullmatch(r"(?:[0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}", value)
+    if compact is None and colon_separated is None and hyphen_separated is None:
+        raise argparse.ArgumentTypeError("must be a valid 48-bit MAC address")
+    return re.sub(r"[:-]", "", value).upper()
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-ni", "--non_interactive", required=False, help="Non-interactive mode", action="store_true")
 parser.add_argument("-u", "--username", required=False, help="Username")
@@ -50,11 +60,18 @@ parser.add_argument("-s", "--server", required=False, help="Server", choices=[*S
 parser.add_argument("-l", "--log_level", required=False, help="Log level", default="CRITICAL", choices=list(NAME_TO_LEVEL.keys()))
 parser.add_argument("-o", "--output", required=False, help="Output file")
 parser.add_argument("--host", required=False, help="Host")
+parser.add_argument("--target-mac", required=False, type=parse_mac_address, help="Only retrieve the BLE key for this MAC address")
+parser.add_argument("--key-output", required=False, help="Write the targeted BLE key to a new owner-only file")
 args = parser.parse_args()
 if args.non_interactive and (not args.username or not args.password):
     parser.error("You need to specify username and password or run as interactive.")
 
 init(autoreset=True)
+
+if (args.target_mac is None) != (args.key_output is None):
+    parser.error("--target-mac and --key-output must be used together.")
+if args.target_mac is not None and not args.non_interactive:
+    parser.error("Targeted BLE key output requires --non_interactive.")
 
 class ColorFormatter(logging.Formatter):
     COLORS = {
@@ -779,6 +796,27 @@ ___ ____ _  _ ____ _  _ ____    ____ _  _ ___ ____ ____ ____ ___ ____ ____
     """)
 
 
+def write_new_private_text_file(path: str, content: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    file_descriptor = os.open(path, flags, 0o600)
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(file_descriptor, 0o600)
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as output_file:
+            file_descriptor = -1
+            output_file.write(content)
+    except Exception:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
 def start_image_server(image: bytes) -> None:
     class ImgHttpHandler(BaseHTTPRequestHandler):
 
@@ -824,7 +862,7 @@ def present_image_image(
             print_if_interactive(message_manually_open_file.format(tmp_path))
 
 
-def main() -> None:
+def main() -> int:
     print_banner()
     if args.non_interactive:
         connector = PasswordXiaomiCloudConnector()
@@ -842,12 +880,16 @@ def main() -> None:
         print_if_interactive()
 
     logged = connector.login()
+    if not logged and args.target_mac is not None:
+        return 1
     if logged:
         print_if_interactive(f"{Fore.GREEN}Logged in.")
         print_if_interactive()
         servers_to_check = get_servers_to_check()
         print_if_interactive()
         output = []
+        target_found = False
+        key_written = False
         for current_server in servers_to_check:
             all_homes = []
             homes = connector.get_homes(current_server)
@@ -871,6 +913,11 @@ def main() -> None:
                         continue
                     print_if_interactive(f'Devices found for server "{current_server}" @ home "{home["home_id"]}":')
                     for device in devices["result"]["device_info"]:
+                        if args.target_mac is not None:
+                            device_mac = re.sub(r"[:-]", "", str(device.get("mac", ""))).upper()
+                            if device_mac != args.target_mac:
+                                continue
+                            target_found = True
                         device_data = {**device}
                         print_tabbed(f"{Fore.BLUE}---------", 3)
                         if "name" in device:
@@ -879,9 +926,20 @@ def main() -> None:
                             print_entry("ID", device["did"], 3)
                             if "blt" in device["did"]:
                                 beaconkey = connector.get_beaconkey(current_server, device["did"])
-                                if beaconkey and "result" in beaconkey and "beaconkey" in beaconkey["result"]:
-                                    print_entry("BLE KEY", beaconkey["result"]["beaconkey"], 3)
+                                if beaconkey and "result" in beaconkey and beaconkey["result"].get("beaconkey"):
+                                    beacon_key = str(beaconkey["result"]["beaconkey"])
+                                    print_entry("BLE KEY", beacon_key, 3)
                                     device_data["BLE_DATA"] = beaconkey["result"]
+                                    if args.key_output and not key_written:
+                                        try:
+                                            write_new_private_text_file(
+                                                args.key_output,
+                                                beacon_key + "\n",
+                                            )
+                                        except OSError as error:
+                                            _LOGGER.error("Unable to write BLE key: %s", error)
+                                            return 1
+                                        key_written = True
                         if "mac" in device:
                             print_entry("MAC", device["mac"], 3)
                         if "localip" in device:
@@ -895,7 +953,17 @@ def main() -> None:
                     print_if_interactive()
                 else:
                     print_if_interactive(f"{Fore.RED}Unable to get devices from server {current_server}.")
+                if key_written and args.output is None:
+                    break
             output.append({"server": current_server, "homes": all_homes})
+            if key_written and args.output is None:
+                break
+        if args.target_mac is not None and not target_found:
+            _LOGGER.error("Target device was not found.")
+            return 1
+        if args.key_output is not None and not key_written:
+            _LOGGER.error("The target device did not provide a BLE key.")
+            return 1
         if args.output:
             with open(args.output, "w") as f:
                 f.write(json.dumps(output, indent=4))
@@ -906,6 +974,7 @@ def main() -> None:
         print_if_interactive()
         print_if_interactive("Press ENTER to finish")
         input()
+    return 0
 
 
 def get_servers_to_check() -> list[str]:
@@ -932,4 +1001,4 @@ def get_servers_to_check() -> list[str]:
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add paired `--target-mac` and `--key-output` options for non-interactive extraction
- validate the target as a 48-bit MAC address before login
- request a BLE key only for the matching device and stop once a key-only lookup succeeds
- create the key file with owner-only permissions on POSIX and refuse to overwrite it
- return a non-zero status without replacing existing JSON output when the target or key is unavailable

## Why

Automation that needs one BLE encryption key currently has to write and parse the account-wide JSON result. The targeted path reduces the amount of secret material written to disk and gives callers a direct success/failure contract.

The new options are independent of authentication method. Existing extraction behavior is unchanged when they are omitted.

## Tests

- `python -m unittest discover -s tests -v` (7 public CLI cases)
- the same feature cases fail against the pre-change executable
- the fixture includes two synthetic BLE devices and proves only the target key is requested
- GitHub Actions runs the suite on Python 3.13 for Ubuntu and Windows

The example MAC is locally administered, and every account value and key in the acceptance fixture is synthetic.
